### PR TITLE
fix php warning about method signature compatibility

### DIFF
--- a/src/config/util/dom/AgaviXmlConfigDomDocument.class.php
+++ b/src/config/util/dom/AgaviXmlConfigDomDocument.class.php
@@ -100,7 +100,7 @@ class AgaviXmlConfigDomDocument extends DOMDocument
 	 * @author     Noah Fontes <noah.fontes@bitextender.com>
 	 * @since      1.0.0
 	 */
-	public function load($filename, $options = 0)
+	public function load($filename, $options = null)
 	{
 		$luie = libxml_use_internal_errors(true);
 		libxml_clear_errors();
@@ -145,7 +145,7 @@ class AgaviXmlConfigDomDocument extends DOMDocument
 	 * @author     Noah Fontes <noah.fontes@bitextender.com>
 	 * @since      1.0.0
 	 */
-	public function loadXml($source, $options = 0)
+	public function loadXml($source, $options = null)
 	{
 		$luie = libxml_use_internal_errors(true);
 		libxml_clear_errors();
@@ -189,7 +189,7 @@ class AgaviXmlConfigDomDocument extends DOMDocument
 	 * @author     Noah Fontes <noah.fontes@bitextender.com>
 	 * @since      1.0.0
 	 */
-	public function xinclude($options = 0)
+	public function xinclude($options = null)
 	{
 		$luie = libxml_use_internal_errors(true);
 		libxml_clear_errors();
@@ -235,7 +235,7 @@ class AgaviXmlConfigDomDocument extends DOMDocument
 	 * @author     Noah Fontes <noah.fontes@bitextender.com>
 	 * @since      1.0.0
 	 */
-	public function importNode(DOMNode $node, $deep)
+	public function importNode(DOMNode $node, $deep = null)
 	{
 		$luie = libxml_use_internal_errors(true);
 		libxml_clear_errors();


### PR DESCRIPTION
``PHP Warning:  Declaration of AgaviXmlConfigDomDocument::importNode(DOMNode $node, $deep) should be compatible with DOMDocument::importNode(DOMNode $importedNode, $deep = NULL) in /app/vendor/agavi/agavi/src/config/util/dom/AgaviXmlConfigDomDocument.class.php on line 238``